### PR TITLE
Add noclamp* variants of left/right/top/bottom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ require you to restart PyGrid.
 }
 ```
 
+##### Available Commands #####
+* `bottomleft` - cycle window sizes which touch both bottom and left screen edges.
+* `bottom` - cycle window sizes which touch the bottom screen edge and are centered horizontally.
+* `bottomright` - cycle window sizes which touch both bottom and right screen edges.
+* `left` - cycle window sizes which touch the left screen edge and are centered vertically.
+* `middle` - cycle window sizes which are centered both horizontally and vertically.
+* `right` - cycle window sizes which touch the right screen edge and are centered vertically.
+* `topleft` - cycle window sizes which touch both top and left screen edges.
+* `top` - cycle window sizes which touch the top screen edge and are centered horizontally.
+* `topright` - cycle window sizes which touch both top and right screen edges.
+* `noclampleft` - cycle window sizes on the left of the screen with the same vertical size.
+* `noclampright` - cycle window sizes on the right of the screen with the same vertical size.
+* `noclamptop` - cycle window sizes at the top of the screen with the same horizontal size.
+* `noclampbottom` - cycle window sizes at the bottom of the screen with the same horizontal size.
+
 #### Installation on Ubuntu ####
 ```bash
 $ sudo apt-get install git python3-gi python3-xlib


### PR DESCRIPTION
The intention behind these new commands is to permit use of grid cells
in the center of the workarea. The default left/right/top/bottom
commands all clamp the left/right/top/bottom edge of the window to the
edge of the workarea, prohibiting use of cells in the center.

For example, given a 3x3 grid, it is not possible with the default
commands to move a window to the center cell (1,1). With larger displays
and larger grids this becomes more problematic.
This patch adds noclamp* variants of the commands which do not clamp to
the respective workarea edge.

By relaxing this positioning restriction, it greatly increases the
number of potential positions for a window. To reduce this (and thus the
number of times the command must be invoked to reach any given position)
the new commands will only resize the window to the closest grid-bounded
size in the axis they are not moving in.
For example: the noclampleft command will not resize the window
vertically, except if necessary to align it to the grid - in which case
it will resize it as little as possible.
This permits intuitive combinations of noclamptop/bottom and
noclampleft/right to be issued to move a window to any desired grid
position.

No default key bindings have been added for the new commands. The README
has been amended to clearly describe all the available commands.