### PR TITLE
Added FreeBSD (maybe all BSDs) support - BSD will create socket witho…

### DIFF
--- a/pygrid.py
+++ b/pygrid.py
@@ -7,11 +7,19 @@ import copy, json, os, signal, socket
 from collections import namedtuple
 from itertools import product
 from Xlib import display, X
+import platform
 
 try:
     # Create singleton using abstract socket (prefix with null)
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind('\0pygrid_singleton_lock')
+
+    # OS distinction
+    # FreeBSD (and probably other BSDs) doesn't work with the '\0', while Linux needs it to work.
+    if 'BSD' in platform.system().upper():
+        sock.bind('pygrid_singleton_lock')
+    else:
+        sock.bind('\0pygrid_singleton_lock')
+
 except socket.error:
     raise SystemExit('PyGrid already running, exiting.')
 


### PR DESCRIPTION
…ut \0 character

That was the only problem while trying to run pygrid on FreeBSD.
All BSDs are similar enough to quite safely assume, it's going to work fine on each of them. Because of this assumption, I'm looking for 'BSD' in system name, though I've tested it only under FreeBSD (and Linux, which was redundant, because there was no way to broke anything – single, simple if).