### PR TITLE
Modified method of forcing single instance. Now it will support FreeBSD (maybe all BSDs).

### DIFF
--- a/pygrid.py
+++ b/pygrid.py
@@ -8,12 +8,9 @@ from collections import namedtuple
 from itertools import product
 from Xlib import display, X
 
-try:
-    # Create singleton using abstract socket (prefix with null)
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind('\0pygrid_singleton_lock')
-except socket.error:
-    raise SystemExit('PyGrid already running, exiting.')
+# Oneliner that protects user from trying to run second PyGrid instance.
+# Works with Linux and FreeBSD (maybe all BSDs) as well.
+import single_process.init
 
 import gi
 gi.require_version('Gtk', '3.0')


### PR DESCRIPTION
Tested on FreeBSD and Linux.
Old locking method didn't work on FreeBSD at all (as well as probably on any other BSD).
New works on Linux as good as the old one, while on FreeBSD it also(!) protects from trying to run second PyGrid instance even from the other location! On Linux both locking methods don't protect from that – it's possible to run multiple instances from multiple directories.
It should never be the case, but it's worth to notice.